### PR TITLE
Add FastMCP-based SSE transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ MINIO_ACCESS_KEY=your_access_key
 MINIO_SECRET_KEY=your_secret_key
 MINIO_SECURE=true
 MINIO_MAX_BUCKETS=5
+MINIO_MAX_KEYS=1000
 
 # Server Configuration
 SERVER_HOST=0.0.0.0
@@ -81,11 +82,27 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 
 ### Running the Server
 
-The server can be run directly:
+Start the server over stdio (the default transport) with:
 
 ```bash
 python src/minio_mcp_server/server.py
 ```
+
+To expose the server over HTTP using Server-Sent Events (SSE) via
+`fastmcp`, choose the `sse` transport. The host and port default to the
+values from `SERVER_HOST`/`SERVER_PORT` (or `0.0.0.0:8000`), and the
+endpoints default to `/sse` for the event stream and `/messages/` for
+message posts:
+
+```bash
+python src/minio_mcp_server/server.py --transport sse --host 0.0.0.0 --port 8000
+```
+
+Set `MCP_TRANSPORT` to `sse`, `streamable-http`, or `stdio` in your
+environment to change the default transport without supplying command
+line flags. Optional `SERVER_SSE_PATH` and `SERVER_MESSAGE_PATH`
+variables let you override the SSE endpoints if you need to align with a
+different MCP client configuration.
 
 ### Using the Basic Client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "mcp>=1.3.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.5.2",
-    "hypercorn>=0.15.0"
+    "hypercorn>=0.15.0",
+    "fastmcp>=2.12.3"
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv>=1.0.0
 pydantic>=2.5.2
 hypercorn>=0.15.0
 mcp>=1.0.0
+fastmcp>=2.12.3

--- a/src/minio_mcp_server/server.py
+++ b/src/minio_mcp_server/server.py
@@ -1,298 +1,306 @@
+"""MinIO MCP server implementation using FastMCP.
+
+This module exposes the MinIO Model Context Protocol (MCP) server with
+both stdio and HTTP/SSE transports powered by the `fastmcp` package.
+"""
+
+from __future__ import annotations
+
+import argparse
 import asyncio
 import base64
-from mcp.server.models import InitializationOptions
-from mcp.server import NotificationOptions, Server
-import mcp.server.stdio
-from dotenv import load_dotenv
 import logging
 import os
-from typing import List, Optional
-from mcp.types import Resource, LoggingLevel, EmptyResult, Tool, TextContent, ImageContent, EmbeddedResource, \
-    BlobResourceContents, ReadResourceResult
+from typing import Any
+from urllib.parse import unquote
+
+from dotenv import load_dotenv
+from fastmcp import FastMCP
+from fastmcp.exceptions import NotFoundError
+from fastmcp.resources.resource import Resource as FastMCPResource
+from fastmcp.server.server import ReadResourceContents
+from pydantic import AnyUrl, Field, PrivateAttr
+
 from resources.minio_resource import MinioResource, is_text_file
-from pydantic import AnyUrl
 
-# Initialize server
-server = Server("minio_service")
 
-# Load environment variables
+# Load environment variables before we create any clients.
 load_dotenv()
 
-# Configure logging
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("mcp_minio_server")
 
-# Get max buckets from environment or use default
-max_buckets = int(os.getenv('MINIO_MAX_BUCKETS', '5'))
 
-# Initialize MinIO resource
-minio_resource = MinioResource(max_buckets=max_buckets)
+DEFAULT_MAX_BUCKETS = int(os.getenv("MINIO_MAX_BUCKETS", "5"))
+DEFAULT_MAX_KEYS = int(os.getenv("MINIO_MAX_KEYS", "1000"))
+DEFAULT_TRANSPORT = os.getenv("MCP_TRANSPORT", "stdio")
+DEFAULT_HOST = os.getenv("SERVER_HOST", "0.0.0.0")
+DEFAULT_PORT = int(os.getenv("SERVER_PORT", "8000"))
 
-
-@server.set_logging_level()
-async def set_logging_level(level: LoggingLevel) -> EmptyResult:
-    logger.setLevel(level.lower())
-    await server.request_context.session.send_log_message(
-        level="info",
-        data=f"Log level set to {level}",
-        logger="mcp_minio_server"
-    )
-    return EmptyResult()
+SSE_PATH = os.getenv("SERVER_SSE_PATH")
+MESSAGE_PATH = os.getenv("SERVER_MESSAGE_PATH")
 
 
-@server.list_resources()
-async def list_resources(start_after: Optional[str] = None) -> List[Resource]:
-    """
-    List MinIO buckets and their contents as resources with pagination
-    Args:
-        start_after: Start listing after this bucket name
-    """
-    resources = []
-    logger.debug("Starting to list resources")
-    logger.debug(f"Configured buckets: {minio_resource.configured_buckets}")
+class MinioObjectResource(FastMCPResource):
+    """FastMCP resource representing a single MinIO object."""
 
-    try:
-        # Get limited number of buckets
-        buckets = await minio_resource.list_buckets(start_after)
+    bucket_name: str = Field(description="Name of the bucket that stores the object")
+    object_name: str = Field(description="Key of the object inside the bucket")
+    is_text: bool = Field(default=False, description="Whether the object should be treated as text")
 
-        # limit concurrent operations
-        async def process_bucket(bucket):
-            bucket_name = bucket['Name']
-            logger.debug(f"Processing bucket: {bucket_name}")
-            try:
-                # List objects in the bucket with a reasonable limit
-                objects = await minio_resource.list_objects(bucket_name, max_keys=1000)
-                for obj in objects:
-                    if 'Key' in obj and not obj['Key'].endswith('/'):
-                        object_key = obj['Key']
-                        mime_type = "text/plain" if is_text_file(
-                            object_key) else "application/octet-stream"
-                        resource = Resource(
-                            uri=f"minio://{bucket_name}/{object_key}",
-                            name=object_key,
-                            mimeType=mime_type
-                        )
-                        resources.append(resource)
-                        logger.debug(f"Added resource: {resource.uri}")
-            except Exception as ex:
-                logger.error(f"Error listing objects in bucket {bucket_name}: {str(ex)}")
+    _minio: MinioResource = PrivateAttr()
 
-        # Use semaphore to limit concurrent bucket processing
-        semaphore = asyncio.Semaphore(3)  # Limit concurrent bucket processing
+    def __init__(self, *, minio_resource: MinioResource, **data: Any) -> None:
+        super().__init__(**data)
+        self._minio = minio_resource
 
-        async def process_bucket_with_semaphore(bucket):
-            async with semaphore:
-                await process_bucket(bucket)
+    async def fetch(self) -> tuple[str | bytes, str]:
+        """Fetch the object content and its MIME type from MinIO."""
 
-        # Process buckets concurrently
-        await asyncio.gather(*[process_bucket_with_semaphore(bucket) for bucket in buckets])
-    except Exception as e:
-        logger.error(f"Error listing buckets: {str(e)}")
-        raise
-
-    return resources
-
-
-@server.read_resource()
-async def read_resource(uri: AnyUrl) -> str:
-    """
-    Read content from a MinIO resource and return structured response
-    """
-    uri_str = str(uri)
-    logger.debug(f"Reading resource: {uri_str}")
-
-    if not uri_str.startswith("minio://"):
-        raise ValueError("Invalid MinIO URI")
-
-    # Parse the MinIO URI
-    from urllib.parse import unquote
-    path = uri_str[8:]  # Remove "minio://"
-    path = unquote(path)  # Decode URL-encoded characters
-    parts = path.split("/", 1)
-
-    if len(parts) < 2:
-        raise ValueError("Invalid MinIO URI format")
-
-    bucket_name = parts[0]
-    key = parts[1]
-    logger.debug(f"Attempting to read - Bucket: {bucket_name}, Key: {key}")
-
-    try:
-        response = await minio_resource.get_object(bucket_name, key)
-        content_type = response.get("ContentType", "application/octet-stream")
-        logger.debug(f"Read MIMETYPE response: {content_type}")
-
-        if 'Body' in response:
-            data = response['Body']
-            # Process the data based on file type
-            if is_text_file(key):
-                text_content = base64.b64encode(data).decode('utf-8')
-                return text_content
-            else:
-                text_content = str(base64.b64encode(data))
-                result = ReadResourceResult(
-                    contents=[
-                        BlobResourceContents(
-                            blob=text_content,
-                            uri=uri_str,
-                            mimeType=content_type
-                        )
-                    ]
-                )
-                logger.debug(result)
-                return text_content
-        else:
-            raise ValueError("No data in response body")
-    except Exception as e:
-        logger.error(f"Error reading object {key} from bucket {bucket_name}: {str(e)}")
-        raise ValueError(f"Error reading resource: {str(e)}")
-
-
-@server.list_tools()
-async def handle_list_tools() -> list[Tool]:
-    return [
-        Tool(
-            name="ListBuckets",
-            description="Returns a list of all buckets owned by the authenticated sender of the request.",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "start_after": {"type": "string", "description": "Start listing after this bucket name"},
-                    "max_buckets": {"type": "integer", "description": "Maximum number of buckets to return"}
-                },
-                "required": [],
-            },
-        ),
-        Tool(
-            name="ListObjects",
-            description="Returns some or all (up to 1,000) of the objects in a bucket with each request.",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "bucket_name": {"type": "string", "description": "Name of the bucket"},
-                    "prefix": {"type": "string",
-                               "description": "Limits the response to keys that begin with the specified prefix"},
-                    "max_keys": {"type": "integer", "description": "Maximum number of keys to return"}
-                },
-                "required": ["bucket_name"],
-            },
-        ),
-        Tool(
-            name="GetObject",
-            description="Retrieves an object from MinIO.",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "bucket_name": {"type": "string", "description": "Name of the bucket"},
-                    "object_name": {"type": "string", "description": "Name of the object to retrieve"}
-                },
-                "required": ["bucket_name", "object_name"]
-            }
-        ),
-        Tool(
-            name="PutObject",
-            description="Uploads a file to MinIO bucket using fput method.",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "bucket_name": {"type": "string", "description": "Name of the bucket"},
-                    "object_name": {"type": "string", "description": "Name to give the object in MinIO"},
-                    "file_path": {"type": "string", "description": "Local file path to upload"}
-                },
-                "required": ["bucket_name", "object_name", "file_path"]
-            }
-        )
-    ]
-
-
-@server.call_tool()
-async def handle_call_tool(
-        name: str, arguments: dict | None
-) -> list[TextContent | ImageContent | EmbeddedResource]:
-    try:
-        match name:
-            case "ListBuckets":
-                buckets = await minio_resource.list_buckets(
-                    start_after=arguments.get("start_after") if arguments else None
-                )
-                return [
-                    TextContent(
-                        type="text",
-                        text=str(buckets)
-                    )
-                ]
-            case "ListObjects":
-                if not arguments or "bucket_name" not in arguments:
-                    raise ValueError("bucket_name is required")
-
-                objects = await minio_resource.list_objects(
-                    bucket_name=arguments["bucket_name"],
-                    prefix=arguments.get("prefix", ""),
-                    max_keys=arguments.get("max_keys", 1000)
-                )
-                return [
-                    TextContent(
-                        type="text",
-                        text=str(objects)
-                    )
-                ]
-            case "GetObject":
-                if not arguments or "bucket_name" not in arguments or "object_name" not in arguments:
-                    raise ValueError("bucket_name and object_name are required")
-
-                response = await minio_resource.get_object(
-                    bucket_name=arguments["bucket_name"],
-                    object_name=arguments["object_name"]
-                )
-                return [
-                    TextContent(
-                        type="text",
-                        text=str(response)
-                    )
-                ]
-            case "PutObject":
-                if (not arguments or
-                        "bucket_name" not in arguments or
-                        "object_name" not in arguments or
-                        "file_path" not in arguments):
-                    raise ValueError("bucket_name, object_name, and file_path are required")
-
-                response = await minio_resource.put_object(
-                    bucket_name=arguments["bucket_name"],
-                    object_name=arguments["object_name"],
-                    file_path=arguments["file_path"]
-                )
-                return [
-                    TextContent(
-                        type="text",
-                        text=str(response)
-                    )
-                ]
-    except Exception as error:
-        return [
-            TextContent(
-                type="text",
-                text=f"Error: {str(error)}"
+        try:
+            response = await self._minio.get_object(self.bucket_name, self.object_name)
+        except Exception as error:  # pragma: no cover - defensive guard
+            logger.error(
+                "Error fetching object %s from bucket %s: %s",
+                self.object_name,
+                self.bucket_name,
+                error,
+                exc_info=True,
             )
-        ]
+            raise NotFoundError(
+                f"Unable to read object {self.object_name} from bucket {self.bucket_name}"
+            ) from error
+
+        data = response.get("Body")
+        if data is None:
+            raise NotFoundError(
+                f"No data returned for object {self.object_name} in bucket {self.bucket_name}"
+            )
+
+        content_type = response.get("ContentType")
+        if not content_type:
+            content_type = "text/plain" if self.is_text else "application/octet-stream"
+
+        if self.is_text:
+            content = base64.b64encode(data).decode("utf-8")
+        else:
+            content = data
+
+        return content, content_type
+
+    async def read(self) -> str | bytes:
+        content, _ = await self.fetch()
+        return content
 
 
-async def main():
-    # Run the server using stdin/stdout streams
-    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream,
-            write_stream,
-            InitializationOptions(
-                server_name="minio-mcp-server",
-                server_version="0.1.0",
-                capabilities=server.get_capabilities(
-                    notification_options=NotificationOptions(),
-                    experimental_capabilities={},
-                ),
-            ),
-        )
+class MinioFastMCP(FastMCP):
+    """FastMCP server that exposes MinIO buckets, objects and tools."""
+
+    def __init__(
+        self,
+        *,
+        minio_resource: MinioResource,
+        max_keys: int = DEFAULT_MAX_KEYS,
+        bucket_concurrency: int = 3,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(name="minio_service", version="0.1.0", **kwargs)
+        self._minio_resource = minio_resource
+        self._max_keys = max_keys
+        self._bucket_concurrency = bucket_concurrency
+        self._resource_cache: dict[str, MinioObjectResource] = {}
+
+    async def _list_resources(self) -> list[FastMCPResource]:
+        base_resources = await super()._list_resources()
+
+        self._resource_cache.clear()
+        resources: list[FastMCPResource] = []
+
+        try:
+            buckets = await self._minio_resource.list_buckets()
+        except Exception as error:
+            logger.error("Error listing MinIO buckets: %s", error, exc_info=True)
+            raise
+
+        semaphore = asyncio.Semaphore(self._bucket_concurrency)
+
+        async def process_bucket(bucket: dict[str, Any]) -> None:
+            bucket_name = bucket["Name"]
+            async with semaphore:
+                try:
+                    objects = await self._minio_resource.list_objects(
+                        bucket_name,
+                        max_keys=self._max_keys,
+                    )
+                except Exception as exc:  # pragma: no cover - network failure guard
+                    logger.error(
+                        "Error listing objects in bucket %s: %s",
+                        bucket_name,
+                        exc,
+                        exc_info=True,
+                    )
+                    return
+
+                for obj in objects:
+                    object_key = obj.get("Key")
+                    if not object_key or object_key.endswith("/"):
+                        continue
+
+                    is_text = is_text_file(object_key)
+                    resource = MinioObjectResource(
+                        uri=f"minio://{bucket_name}/{object_key}",
+                        name=object_key,
+                        mime_type="text/plain" if is_text else "application/octet-stream",
+                        bucket_name=bucket_name,
+                        object_name=object_key,
+                        is_text=is_text,
+                        minio_resource=self._minio_resource,
+                    )
+                    self._resource_cache[resource.key] = resource
+                    resources.append(resource)
+
+        await asyncio.gather(*(process_bucket(bucket) for bucket in buckets))
+
+        return base_resources + resources
+
+    async def _read_resource(self, uri: AnyUrl | str) -> list[ReadResourceContents]:
+        try:
+            return await super()._read_resource(uri)
+        except NotFoundError as original_error:
+            uri_str = str(uri)
+
+            resource = self._resource_cache.get(uri_str)
+            if resource is None:
+                if not uri_str.startswith("minio://"):
+                    raise original_error
+
+                try:
+                    bucket_name, object_name = self._parse_minio_uri(uri_str)
+                except ValueError as parse_error:
+                    raise original_error from parse_error
+
+                is_text = is_text_file(object_name)
+                resource = MinioObjectResource(
+                    uri=uri_str,
+                    name=object_name,
+                    mime_type="text/plain" if is_text else "application/octet-stream",
+                    bucket_name=bucket_name,
+                    object_name=object_name,
+                    is_text=is_text,
+                    minio_resource=self._minio_resource,
+                )
+
+            content, mime_type = await resource.fetch()
+            return [ReadResourceContents(content=content, mime_type=mime_type)]
+
+    @staticmethod
+    def _parse_minio_uri(uri: str) -> tuple[str, str]:
+        if not uri.startswith("minio://"):
+            raise ValueError(f"Unsupported URI scheme: {uri}")
+
+        path = unquote(uri[len("minio://") :])
+        if "/" not in path:
+            raise ValueError(f"Invalid MinIO URI: {uri}")
+
+        bucket_name, object_name = path.split("/", 1)
+        if not bucket_name or not object_name:
+            raise ValueError(f"Invalid MinIO URI: {uri}")
+
+        return bucket_name, object_name
+
+
+minio_resource = MinioResource(max_buckets=DEFAULT_MAX_BUCKETS)
+
+server_kwargs: dict[str, Any] = {}
+if SSE_PATH:
+    server_kwargs["sse_path"] = SSE_PATH
+if MESSAGE_PATH:
+    server_kwargs["message_path"] = MESSAGE_PATH
+
+server = MinioFastMCP(minio_resource=minio_resource, **server_kwargs)
+
+
+@server.tool(name="ListBuckets", description="Return available MinIO buckets")
+async def list_buckets_tool(start_after: str | None = None, max_buckets: int | None = None) -> list[dict[str, Any]]:
+    logger.debug("Listing buckets start_after=%s max_buckets=%s", start_after, max_buckets)
+    buckets = await minio_resource.list_buckets(start_after)
+    if max_buckets is not None:
+        buckets = buckets[:max_buckets]
+    return buckets
+
+
+@server.tool(
+    name="ListObjects",
+    description="List objects stored in a MinIO bucket",
+)
+async def list_objects_tool(
+    bucket_name: str,
+    prefix: str = "",
+    max_keys: int = DEFAULT_MAX_KEYS,
+) -> list[dict[str, Any]]:
+    logger.debug(
+        "Listing objects for bucket=%s prefix=%s max_keys=%s",
+        bucket_name,
+        prefix,
+        max_keys,
+    )
+    return await minio_resource.list_objects(bucket_name, prefix=prefix, max_keys=max_keys)
+
+
+@server.tool(name="GetObject", description="Fetch an object's metadata and data from MinIO")
+async def get_object_tool(bucket_name: str, object_name: str) -> dict[str, Any]:
+    logger.debug("Fetching object bucket=%s key=%s", bucket_name, object_name)
+    response = await minio_resource.get_object(bucket_name, object_name)
+    body = response.get("Body")
+    if isinstance(body, bytes):
+        response = {**response, "Body": base64.b64encode(body).decode("utf-8")}
+    return response
+
+
+@server.tool(name="PutObject", description="Upload a local file to a MinIO bucket")
+async def put_object_tool(bucket_name: str, object_name: str, file_path: str) -> dict[str, Any]:
+    logger.debug(
+        "Uploading object bucket=%s key=%s from path=%s",
+        bucket_name,
+        object_name,
+        file_path,
+    )
+    return await minio_resource.put_object(bucket_name, object_name, file_path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the MinIO MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "http", "streamable-http"],
+        default=DEFAULT_TRANSPORT,
+        help="Transport protocol to use",
+    )
+    parser.add_argument(
+        "--host",
+        default=DEFAULT_HOST,
+        help="Host to bind for HTTP/SSE transports",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help="Port to bind for HTTP/SSE transports",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    transport = args.transport
+
+    run_kwargs: dict[str, Any] = {}
+    if transport in {"sse", "http", "streamable-http"}:
+        run_kwargs.update(host=args.host, port=args.port)
+
+    server.run(transport=transport, **run_kwargs)
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
## Summary
- replace the MinIO MCP server implementation with FastMCP so it can run over stdio or HTTP/SSE
- expose the existing MinIO tools and resources through the new server, including CLI flags and env vars for transport configuration
- document SSE usage and declare the new fastmcp dependency

## Testing
- python -m compileall src


------
https://chatgpt.com/codex/tasks/task_e_68ce0ed13e6c8323b44c6d56ff29a3f9